### PR TITLE
Multiple middleware support & Response class

### DIFF
--- a/src/Classes/BaseMiddleware.ts
+++ b/src/Classes/BaseMiddleware.ts
@@ -1,6 +1,6 @@
-import http from 'http';
+import {ServerResponse} from 'node:http';
 import {Request} from './';
 
 export default abstract class BaseMiddleware {
-	abstract run(req: Request, res: http.ServerResponse): void;
+	abstract run(req: Request, res: ServerResponse): void;
 }

--- a/src/Classes/BaseMiddleware.ts
+++ b/src/Classes/BaseMiddleware.ts
@@ -1,5 +1,5 @@
-import {ServerResponse} from 'node:http';
-import {Request} from './';
+import { ServerResponse } from 'node:http';
+import { Request } from './';
 
 export default abstract class BaseMiddleware {
 	abstract run(req: Request, res: ServerResponse): void;

--- a/src/Classes/BaseMiddleware.ts
+++ b/src/Classes/BaseMiddleware.ts
@@ -2,5 +2,5 @@ import http from 'http';
 import {Request} from './';
 
 export default abstract class BaseMiddleware {
-	abstract run(req: Request, res: http.ServerResponse, next: () => void): void;
+	abstract run(req: Request, res: http.ServerResponse): void;
 }

--- a/src/Classes/Request.ts
+++ b/src/Classes/Request.ts
@@ -1,5 +1,5 @@
-import {IncomingHttpHeaders, IncomingMessage} from 'node:http';
-import {DefaultBodyType, Method} from './';
+import { IncomingHttpHeaders, IncomingMessage } from 'node:http';
+import { DefaultBodyType, Method } from './';
 
 export default class Request {
 

--- a/src/Classes/Request.ts
+++ b/src/Classes/Request.ts
@@ -18,7 +18,9 @@ export default class Request {
 				body += chunk;
 			});
 			r.on('end', () => {
-				this.body = JSON.parse(body);
+				if (body.length) {
+					this.body = JSON.parse(body);
+				}
 				resolve(this);
 			});
 		});

--- a/src/Classes/Response.ts
+++ b/src/Classes/Response.ts
@@ -1,0 +1,15 @@
+import {OutgoingHttpHeaders, ServerResponse} from 'node:http';
+export default class Response {
+
+	private readonly rawResponse: ServerResponse;
+
+	constructor (res: ServerResponse) {
+		this.rawResponse = res;
+	}
+
+	public send<Body> (body: Body, statusCode: number, headers: OutgoingHttpHeaders) {
+		this.rawResponse.writeHead(statusCode, headers);
+		this.rawResponse.write(JSON.stringify(body));
+		return this.rawResponse.end();
+	}
+}

--- a/src/Classes/Response.ts
+++ b/src/Classes/Response.ts
@@ -1,4 +1,4 @@
-import {OutgoingHttpHeaders, ServerResponse} from 'node:http';
+import { OutgoingHttpHeaders, ServerResponse } from 'node:http';
 export default class Response {
 
 	private readonly rawResponse: ServerResponse;

--- a/src/Classes/Server.ts
+++ b/src/Classes/Server.ts
@@ -1,5 +1,5 @@
-import {createServer, Server as HttpServer, IncomingMessage, ServerResponse} from 'http';
-import {CallBackType, Method, Request, BaseMiddleware, MethodStringType} from './';
+import {createServer, Server as HttpServer, IncomingMessage, ServerResponse} from 'node:http';
+import {CallBackType, Method, Request, Response, BaseMiddleware, MethodStringType} from './';
 
 export default class Server {
 
@@ -44,6 +44,8 @@ export default class Server {
 		this.getListener().on('request', (req: IncomingMessage, res: ServerResponse) => {
 			if (req.url === route && req.method === method) {
 
+				const response = new Response(res);
+
 				new Request()
 					.setHeaders(req.headers)
 					.setMethod(method)
@@ -56,12 +58,10 @@ export default class Server {
 								resolve(true);
 							});
 						}).then(() => {
-							const response = callback(request, res);
-							res.writeHead(200, {'Content-Type': 'application/json'});
-							res.end(JSON.stringify(response));
+							const json = callback(request, response);
+							response.send(json, 200, {'Content-Type': 'application/json'});
 						}).catch((e) => {
-							res.writeHead(400, {'Content-Type': 'application/json'});
-							res.end(JSON.stringify({message: e.message}));
+							response.send({message: e.message}, 400, {'Content-Type': 'application/json'});
 						});
 					});
 			}

--- a/src/Classes/Server.ts
+++ b/src/Classes/Server.ts
@@ -1,5 +1,18 @@
-import {createServer, Server as HttpServer, IncomingMessage, ServerResponse} from 'node:http';
-import {CallBackType, Method, Request, Response, BaseMiddleware, MethodStringType} from './';
+import {
+	createServer,
+	Server as HttpServer,
+	IncomingMessage,
+	ServerResponse
+} from 'node:http';
+
+import {
+	CallBackType,
+	Method,
+	Request,
+	Response,
+	BaseMiddleware,
+	MethodStringType
+} from './';
 
 export default class Server {
 

--- a/src/Classes/Server.ts
+++ b/src/Classes/Server.ts
@@ -1,9 +1,9 @@
-import http, {createServer} from 'http';
+import {createServer, Server as HttpServer, IncomingMessage, ServerResponse} from 'http';
 import {CallBackType, Method, Request, BaseMiddleware, MethodStringType} from './';
 
 export default class Server {
 
-	private listener: http.Server<typeof http.IncomingMessage, typeof http.ServerResponse> | null = null;
+	private listener: HttpServer<typeof IncomingMessage, typeof ServerResponse> | null = null;
 
 	constructor () {}
 
@@ -13,7 +13,7 @@ export default class Server {
 		});
 	}
 
-	private getListener (): http.Server<typeof http.IncomingMessage, typeof http.ServerResponse>  {
+	private getListener (): HttpServer<typeof IncomingMessage, typeof ServerResponse>  {
 		if (this.listener === null) {
 			this.listener = createServer();
 		}
@@ -41,7 +41,7 @@ export default class Server {
 	}
 
 	public request<T> (route: string, method: Method | MethodStringType, callback: CallBackType<T>, middlewares: Array<BaseMiddleware> = []) {
-		this.getListener().on('request', (req: http.IncomingMessage, res: http.ServerResponse) => {
+		this.getListener().on('request', (req: IncomingMessage, res: ServerResponse) => {
 			if (req.url === route && req.method === method) {
 
 				new Request()

--- a/src/Classes/index.ts
+++ b/src/Classes/index.ts
@@ -1,8 +1,9 @@
 import Server from './Server';
 import Request from './Request';
+import Response from './Response';
 import BaseMiddleware from './BaseMiddleware';
 
-export { Server, Request, BaseMiddleware };
+export { Server, Request, Response, BaseMiddleware };
 
 export * from './types';
 

--- a/src/Classes/types.ts
+++ b/src/Classes/types.ts
@@ -9,6 +9,12 @@ export enum Method {
 	PATCH = 'PATCH'
 }
 
+export type MethodStringType = Method.GET
+	| Method.POST
+	| Method.PUT
+	| Method.DELETE
+	| Method.PATCH;
+
 export type CallBackType<T> = (req: Request, res: http.ServerResponse) => T;
 
 export type DefaultBodyType = NonNullable<unknown>;

--- a/src/Classes/types.ts
+++ b/src/Classes/types.ts
@@ -1,4 +1,4 @@
-import http from 'http';
+import {ServerResponse} from 'http';
 import {Request} from './';
 
 export enum Method {
@@ -15,6 +15,6 @@ export type MethodStringType = Method.GET
 	| Method.DELETE
 	| Method.PATCH;
 
-export type CallBackType<T> = (req: Request, res: http.ServerResponse) => T;
+export type CallBackType<T> = (req: Request, res: ServerResponse) => T;
 
 export type DefaultBodyType = NonNullable<unknown>;

--- a/src/Classes/types.ts
+++ b/src/Classes/types.ts
@@ -1,5 +1,4 @@
-import {ServerResponse} from 'http';
-import {Request} from './';
+import {Request, Response} from './';
 
 export enum Method {
 	GET = 'GET',
@@ -15,6 +14,6 @@ export type MethodStringType = Method.GET
 	| Method.DELETE
 	| Method.PATCH;
 
-export type CallBackType<T> = (req: Request, res: ServerResponse) => T;
+export type CallBackType<T> = (req: Request, res: Response) => T;
 
 export type DefaultBodyType = NonNullable<unknown>;


### PR DESCRIPTION
Add :
- Response class

Edit :
- Now support multiple middlewares per listener
- Imports types from `node:http` instead of `http`
- Clean code
- Fix empty body from GET requests

Delete :
- next() function in middleware